### PR TITLE
Update step.yml - Update dependency-checker (cocoapods) stuff

### DIFF
--- a/SIDI/steps/_audit_packages_third_parties/codemagic/step.yml
+++ b/SIDI/steps/_audit_packages_third_parties/codemagic/step.yml
@@ -4,33 +4,58 @@ script: |
    #!/bin/sh
    set -ex
    
-   fail_on_cvss_level="$FAIL_ON_CVSS_LEVEL"
-   podfile_lock_path="./$IOS_PROJECT_ROOT/Podfile.lock"
-
-   if [ "$fail_on_cvss_level" == "" ]
-   then
-      fail_on_cvss_level="9"
-      echo "fail_on_cvss_level set per default to $fail_on_cvss_level"
+   fail_on_cvss_level="${FAIL_ON_CVSS_LEVEL}"
+   
+   if [ -z "$fail_on_cvss_level" ]; then
+     fail_on_cvss_level="9"
+     echo "⚠️ fail_on_cvss_level not set, defaulting to $fail_on_cvss_level"
    fi
-
-   echo "[AUDIT] - Audit iOS 3rd parties dependencies"
+   
+   echo "🔍 [AUDIT] - Starting iOS 3rd party dependency check"
+   
+   # Ensure brew is available
+   if ! command -v brew >/dev/null 2>&1; then
+     echo "❌ Homebrew not found. Please install Homebrew first."
+     exit 1
+   fi
    
    brew install dependency-check
-
+   
    mkdir -p "$CM_EXPORT_DIR/reports/cocoapods"
-   dependency-check --failOnCVSS=$fail_on_cvss_level --enableExperimental --project $CM_PROJECT_ID --scan $podfile_lock_path --noupdate --format HTML --format JSON --out $CM_EXPORT_DIR/reports/cocoapods
-
-   echo "Audit IOS dependencies done successfully"
+   
+   if [ ! -f "$podfile_lock_path" ]; then
+     echo "❌ Podfile.lock not found at $podfile_lock_path"
+     exit 1
+   fi
+   
+   dependency-check \
+     --failOnCVSS="$fail_on_cvss_level" \
+     --enableExperimental \
+     --project "$CM_PROJECT_ID" \
+     --scan "$podfile_lock_path" \
+     --noupdate \
+     --format HTML \
+     --format JSON \
+     --out "$CM_EXPORT_DIR/reports/cocoapods"
+   
+   echo "✅ iOS dependency audit completed"
    
    echo "--------------------------------------------------------------------"
-   echo "[AUDIT] - Audit Android 3rd parties dependencies"
+   echo "🔍 [AUDIT] - Starting Android 3rd party dependency check"
    
-   cd $GRADLEW_PATH
-   #Run analyze
+   if [ ! -d "$GRADLEW_PATH" ]; then
+     echo "❌ GRADLEW_PATH '$GRADLEW_PATH' does not exist"
+     exit 1
+   fi
+   
+   cd "$GRADLEW_PATH"
    mkdir -p "$CM_EXPORT_DIR/reports/gradle"
-   ./gradlew $ANDROID_MODULE_NAME:dependencyCheckAggregate
-   cd $CM_EXPORT_DIR
-   # Rename file to allow other dependency checker to be executed and stored in the artifact folder
-   mv $CM_EXPORT_DIR/dependency-check-report.html $CM_EXPORT_DIR/gradle-dependency-check-report.html
    
-   echo "Audit packages finished successfully"
+   ./gradlew "$ANDROID_MODULE_NAME:dependencyCheckAggregate"
+   
+   cd "$CM_EXPORT_DIR"
+   mv "$CM_EXPORT_DIR/dependency-check-report.html" "$CM_EXPORT_DIR/gradle-dependency-check-report.html"
+   
+   echo "✅ Android dependency audit completed"
+   
+   echo "🎉 All audits finished successfully!"

--- a/SIDI/steps/_audit_packages_third_parties/codemagic/step.yml
+++ b/SIDI/steps/_audit_packages_third_parties/codemagic/step.yml
@@ -27,6 +27,7 @@ script: |
    
    cd $GRADLEW_PATH
    #Run analyze
+   mkdir -p "$CM_EXPORT_DIR/reports/gradle"
    ./gradlew $ANDROID_MODULE_NAME:dependencyCheckAggregate
    cd $CM_EXPORT_DIR
    # Rename file to allow other dependency checker to be executed and stored in the artifact folder

--- a/SIDI/steps/_audit_packages_third_parties/codemagic/step.yml
+++ b/SIDI/steps/_audit_packages_third_parties/codemagic/step.yml
@@ -16,10 +16,9 @@ script: |
    echo "[AUDIT] - Audit iOS 3rd parties dependencies"
    
    brew install dependency-check
-   
-   dependency-check --failOnCVSS=$fail_on_cvss_level --enableExperimental --project $CM_PROJECT_ID --out $CM_EXPORT_DIR --scan $podfile_lock_path
-   # Rename file to allow other dependency checker to be executed and stored in the artifact folder
-   mv $CM_EXPORT_DIR/dependency-check-report.html $CM_EXPORT_DIR/cocoapods-dependency-check-report.html
+
+   mkdir -p "$CM_EXPORT_DIR/reports/cocoapods"
+   dependency-check --failOnCVSS=$fail_on_cvss_level --enableExperimental --project $CM_PROJECT_ID --scan $podfile_lock_path --noupdate --format HTML --format JSON --out $CM_EXPORT_DIR/reports/cocoapods
 
    echo "Audit IOS dependencies done successfully"
    


### PR DESCRIPTION
The script no longer works without the --noupdate flag or a valid license key.
Since we reinstall the dependency every time, we don’t need to check for updates anyway.

TBC for the bitrise stuff